### PR TITLE
TECH-2575 convert header to webpacker: eslint currently errors when...

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -125,6 +125,6 @@
     "array-bracket-spacing": ["error", "never"],
     "object-curly-spacing": ["error", "always"],
     "no-extra-semi": "error",
-    "react/no-deprecated": 0
+    "react/no-deprecated": "off"
   }
 }

--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -8,7 +8,7 @@
   "parserOptions": {
     "sourceType": "module"
   },
-  "extends": "standard",
+  "extends": ["standard", "plugin:react/recommended"],
   "globals": {
     "document": false,
     "navigator": false,
@@ -124,6 +124,7 @@
     "quotes": "off",
     "array-bracket-spacing": ["error", "never"],
     "object-curly-spacing": ["error", "always"],
-    "no-extra-semi": "error"
+    "no-extra-semi": "error",
+    "react/no-deprecated": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
-    "eslint-plugin-standard": "^3.1.0"
+    "eslint-plugin-standard": "^3.1.0",
+    "eslint-plugin-react": "7.10.0"
   },
   "bugs": {
     "url": "https://github.com/Invoca/style-guide/issues"


### PR DESCRIPTION
importing react components

This adds the React plugin for Eslint and since our React uses an ancient version, we extend the recommended settings with the exception of allowing deprecated features.