### PR TITLE
disable "Use match? instead of =~ when MatchData is not used." and "Use @ivar.positive? instead of @ivar > 0."

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -77,6 +77,9 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 10
 
+Performance/RegexpMatch:
+  Enabled: false
+
 Performance/StringReplacement:
   Enabled: false
 
@@ -130,6 +133,9 @@ Style/Next:
 Style/NumericLiterals:
   MinDigits: 9
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/PreferredHashMethods:
   Enabled: false
 
@@ -156,3 +162,4 @@ Style/TrailingCommaInHashLiteral:
 
 Style/WordArray:
   Enabled: false
+  


### PR DESCRIPTION
@primiti  Can you review? I tested these changes interactively like you suggested.