### PR TITLE
Add react/jsx-uses-vars rule

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -125,6 +125,7 @@
     "array-bracket-spacing": ["error", "never"],
     "object-curly-spacing": ["error", "always"],
     "no-extra-semi": "error",
-    "react/no-deprecated": "off"
+    "react/no-deprecated": "off",
+    "react/jsx-uses-vars": [2]
   }
 }


### PR DESCRIPTION
For this issue `'NewComponent' is defined but never used no-unused-vars`

Source: https://github.com/eslint/eslint/issues/6303