### PR TITLE
disable Naming/VariableNumber cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -81,7 +81,10 @@ Metrics/PerceivedComplexity:
   Max: 10
 
 Naming/HeredocDelimiterNaming:	
-  Enabled: false	
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
 
 Performance/RegexpMatch:
   Enabled: false


### PR DESCRIPTION
Rubcop complains about variables like `found_utf_16` or `sha256`.  This isn't in our style guide.
