### PR TITLE
hound rubocop version: update hound preferred rubocop version

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,9 @@
 ruby:
   config_file: ./ruby/.rubocop.yml
 
+rubocop:
+  version: 0.72.0
+
 jshint:
   enabled: false
 


### PR DESCRIPTION
http://help.houndci.com/en/articles/2489940-linter-versioning
http://help.houndci.com/en/articles/2461415-supported-linters

Bumping the rubocop version for hound
