### PR TITLE
ESLint Async Error Function Spacing

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -23,7 +23,7 @@
     "space-in-parens": "error",
     "eqeqeq": "error",
     "no-unneeded-ternary": ["error", { "defaultAssignment": false }],
-    "space-before-function-paren": ["error", "never"],
+    "space-before-function-paren": ["error", { "anonymous": "never", "named": "never", "asyncArrow": "always" }],
     "semi": ["error", "always"],
     "quotes": "off",
     "array-bracket-spacing": ["error", "never"],


### PR DESCRIPTION
This PR turns on "always" for enforcing a space after async arrow function.