### PR TITLE
Allow curly braces when sending hashes as arguments

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -99,6 +99,9 @@ Naming/VariableNumber:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/BracesAroundHashParameters:
+  Enabled: true
+
 Style/ClassAndModuleChildren:
   Enabled: true
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -645,6 +645,23 @@ result = hash.map { |k, v| v + 1 }
 result = hash.map { |_, v| v + 1 }
 ```
 
+### Use '{}' when passing a hash as an argument, but not for keyword args.
+```ruby
+def foo(a:, b:)
+#...
+end
+
+foo({a: 1, b: 2}) # bad
+foo(a: 1, b: 2) # good
+
+def bar(options = {})
+# ...
+end
+
+bar(a: 1, b: 2) # bad
+bar({ a: 1, b: 2 }) # good
+```
+
 ## Naming
 
 ### Use `snake_case` for methods and variables.


### PR DESCRIPTION
Hound has had the rule:
"Style/BracesAroundHashParameters: Redundant curly braces around a hash parameter."
https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/BracesAroundHashParameters

which I feel like it obfuscates the fact that we need to pass a hash to a method. It's more explicit to pass it as a hash when you're using the hash directly in the called method.

More importantly ruby is actually changing how it deals with hashes in 3.0 in a way that will likely cause this rule to change anyway:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
