### PR TITLE
Remove curly brace requirement for ruby 3

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -100,7 +100,7 @@ Style/AndOr:
   EnforcedStyle: conditionals
 
 Style/BracesAroundHashParameters:
-  Enabled: true
+  Enabled: false
 
 Style/ClassAndModuleChildren:
   Enabled: true

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -645,7 +645,7 @@ result = hash.map { |k, v| v + 1 }
 result = hash.map { |_, v| v + 1 }
 ```
 
-### Do not rely on a hash being destructured into keyword args.
+### Do not rely on a hash being destructured into keyword args, because Ruby 3 will remove this implicit behavior. Instead, use `**`.
 ```ruby
 def foo(a:, b:)
 # ...
@@ -654,9 +654,9 @@ end
 foo({ a: 1, b: 2 }) # bad
 foo(a: 1, b: 2) # good
 
-params = { a: 1, b: 2 }
-foo(params) # bad
-foo(**params) # good
+options = { a: 1, b: 2 }
+foo(options) # bad
+foo(**options) # good
 ```
 
 ### Use '{}' when passing a hash as an argument for a method that also includes keyword args.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -645,21 +645,25 @@ result = hash.map { |k, v| v + 1 }
 result = hash.map { |_, v| v + 1 }
 ```
 
-### Use '{}' when passing a hash as an argument, but not for keyword args.
+### Do not use a hash literal to destructure keyword args.
 ```ruby
 def foo(a:, b:)
-#...
-end
-
-foo({a: 1, b: 2}) # bad
-foo(a: 1, b: 2) # good
-
-def bar(options = {})
 # ...
 end
 
-bar(a: 1, b: 2) # bad
-bar({ a: 1, b: 2 }) # good
+foo({ a: 1, b: 2 }) # bad
+foo(**{ a: 1, b: 2 }) # better
+foo(a: 1, b: 2) # best
+```
+
+### Use '{}' when passing a hash as an argument for a method that also includes keyword args.
+```ruby
+def baz(options = {}, c:, d:)
+# ...
+end
+
+baz(a: 1, b: 2, c: 3, d: 4) # bad
+baz({ a: 1, b: 2 }, c: 3, d: 4) # good
 ```
 
 ## Naming

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -645,15 +645,18 @@ result = hash.map { |k, v| v + 1 }
 result = hash.map { |_, v| v + 1 }
 ```
 
-### Do not use a hash literal to destructure keyword args.
+### Do not rely on a hash being destructured into keyword args.
 ```ruby
 def foo(a:, b:)
 # ...
 end
 
 foo({ a: 1, b: 2 }) # bad
-foo(**{ a: 1, b: 2 }) # better
-foo(a: 1, b: 2) # best
+foo(a: 1, b: 2) # good
+
+params = { a: 1, b: 2 }
+foo(params) # bad
+foo(**params) # good
 ```
 
 ### Use '{}' when passing a hash as an argument for a method that also includes keyword args.
@@ -664,6 +667,16 @@ end
 
 baz(a: 1, b: 2, c: 3, d: 4) # bad
 baz({ a: 1, b: 2 }, c: 3, d: 4) # good
+```
+
+### Omit {} when passing options hashes at the end of method calls, to enable them to be converted to keyword args in the future without having to change the calling code.
+```ruby
+def bar(name, value, options = {})
+# ...
+end
+
+bar("John", 10, { a: 1, b: 2 }) # bad
+bar("John", 10, a: 1, b: 2) # good
 ```
 
 ## Naming


### PR DESCRIPTION
* Disable `Style/BracesAroundHashParameters` in order to prep for Ruby 3 changes.
* Add examples to README
  * `Do not use a hash literal to destructure keyword args.`
  * `Use '{}' when passing a hash as an argument for a method that also includes keyword args.`
* Remove examples from README
  * `Use '{}' when passing a hash as an argument, but not for keyword args.`