### PR TITLE
format enforce templated string formatting

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -131,6 +131,12 @@ Style/EachWithObject:
 Style/EmptyMethod:
   Enabled: false
 
+Style/FormatStringToken:
+  Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 Style/GuardClause:
   Enabled: false
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1046,6 +1046,17 @@ html = paragraphs.map do |paragraph|
 end.join
 ```
 
+### Formatting - Prefer Templated String Formatting
+```ruby
+# bad
+format("%s", "Hello")
+"%<greeting>s" % { greeting: "Hello" }
+
+# good
+format("%{greeting}", greeting: "Hello")
+"%{greeting}, %{user}!" % { greeting: "Hello", name: "User" }
+```
+
 ## Constants
 `CamelCase` constants should be used only to name classes and modules. `ALL_CAPS` constants should always be immutable values, and frozen to guarantee that.
 ```ruby


### PR DESCRIPTION
See [this slack thread](https://invoca.slack.com/archives/C8P8R355G/p1587677133001600) for more context.

Prefer using templated string format to make it clear what you're formatting (extra beneficial for the use case where there are multiple values you are templating)