### PR TITLE
no-jira: drop CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-.hound.yml           @alecjacobs5401
-ruby/.rubocop.yml    @alecjacobs5401 @peterwilson @colindkelley
-scss/.scss-lint.yml  @nburwell


### PR DESCRIPTION
@alecjacobs5401 @peterwilson @nburwell 
I've enabled the `github` setting that requires at least one approval for any PR to be merged in this repo. Given that, I don't think any of us need to be "CODEOWNERS". We can still watch the repo if we like.