### PR TITLE
No JIRA: Remove invalid Layout/HeredocIndentation cop config

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -32,9 +32,6 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: false
 
-Layout/HeredocIndentation:
-  EnforcedStyle: unindent
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 


### PR DESCRIPTION
This parameter isn't valid, I suspect something changed with the bump to rubocop 0.91.0.  The cop is enabled by default, so removing the offending parameter should be a noop.

@alecjacobs5401 and @ColinDKelley: git says you were both recently in the area, so I've tagged you for review.

```
Warning: Layout/HeredocIndentation does not support EnforcedStyle parameter.

Supported parameters are:

  - Enabled
```