### PR TITLE
no-jira: disable hyphenated_BEM css rule

### DIFF
--- a/scss/.scss-lint.yml
+++ b/scss/.scss-lint.yml
@@ -160,8 +160,7 @@ linters:
     max_depth: 4
 
   SelectorFormat:
-    enabled: true
-    convention: hyphenated_BEM # or 'strict_BEM', or 'hyphenated_lowercase', or 'snake_case', or 'camel_case', or a regex pattern
+    enabled: false
 
   Shorthand:
     enabled: false


### PR DESCRIPTION
Our `web` repo has a lot of legacy code with dynamically generated `snake_case` classnames. Often times, during a simple code update, Hound will complain that these classes are not valid, causing us to either find/replace/refactor a large amount of code (which can be risky, or at the very least increase the scope of the case), or put ignore statements around the CSS rules.

Brought these concerns to the UI guild meeting and we decided it was fine to simply update the linter rules to remove `hyphenated_BEM` enforcement. 

This Jira is to disable that rule.