### PR TITLE
Enable new cops by default, bump target ruby version to match web

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,6 @@
 # Examples of how to specifically exclude certain things
 AllCops:
-  TargetRubyVersion: 2.6.1
+  TargetRubyVersion: 2.7.5
   Exclude:
     - '**/*.yml'
     - '**/*.sql'
@@ -12,6 +12,7 @@ AllCops:
     - '**/db/migrate/**/*.rb'
     - '**/db/schema.rb'
     - !ruby/regexp /old_and_unused\.rb$/
+  NewCops: enable
 
 # Configure cops for styles that we do not adhere to or are not agreed upon
 # Default settings and options can be viewed here: https://raw.githubusercontent.com/bbatsov/rubocop/master/config/default.yml


### PR DESCRIPTION
As a passion project I am trying to bump the rubocop version in the web repo.   When it is bumped it complains about cops that are not mentioned.  This change fixes it so that it will not complain.   We may need to come back and tune things later.