### PR TITLE
STORY-14443 - Address breaking change introduced by rubocop in 0.78.0 on  2019-12-18

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -21,9 +21,6 @@ AllCops:
 Layout/AccessModifierIndentation:
   IndentationWidth: 2
 
-Layout/HashAlignment:
-  Enabled: false
-
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
@@ -32,6 +29,14 @@ Layout/EndOfLine:
 
 Layout/ExtraSpacing:
   Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 150
+  Exclude:
+    - '**/*_test.rb'
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
@@ -69,11 +74,6 @@ Metrics/ClassLength:
 
 Metrics/CyclomaticComplexity:
   Max: 10
-
-Metrics/LineLength:
-  Max: 150
-  Exclude:
-    - '**/*_test.rb'
 
 Metrics/MethodLength:
   Max: 20


### PR DESCRIPTION
- Move the LineLength cop configuration to the appropriate namespace

[Jira Story](https://invoca.atlassian.net/browse/STORY-14443) 
