### PR TITLE
non-production: disable RSpec/NotToNot

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -97,6 +97,9 @@ Naming/RescuedExceptionsVariableName:
 Naming/VariableNumber:
   Enabled: false
 
+RSpec/NotToNot
+  Enabled: false
+
 Style/AndOr:
   EnforcedStyle: conditionals
 


### PR DESCRIPTION
This PR disables the `RSpec/NotToNot` cop. By default that's enabled, and it complains about our common usage
```
expect(r).to_not receive(:puts)
```