### PR TITLE
Fix cop style

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -97,7 +97,7 @@ Naming/RescuedExceptionsVariableName:
 Naming/VariableNumber:
   Enabled: false
 
-RSpec/NotToNot
+RSpec/NotToNot:
   Enabled: false
 
 Style/AndOr:


### PR DESCRIPTION
Seeing failed Hound errors.

https://github.com/Invoca/web/pull/21187 Hound — ./ruby/.rubocop.yml format is invalid 

Proof that it works fine with Hound https://github.com/Invoca/web/pull/21188
