### PR TITLE
Revert "non-production: disable RSpec/NotToNot"

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -97,9 +97,6 @@ Naming/RescuedExceptionsVariableName:
 Naming/VariableNumber:
   Enabled: false
 
-RSpec/NotToNot:
-  Enabled: false
-
 Style/AndOr:
   EnforcedStyle: conditionals
 


### PR DESCRIPTION
This reverts commit 23cde1ed4af737dd704e2193bbab5e3b2fefa062 and the `:` fix.