### PR TITLE
NON-PROD remove config from exclude folder

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
   Exclude:
     - '**/*.yml'
     - '**/*.sql'
-    - 'config/**/*'
     - 'vendor/bundle/**/*'
     - 'vendor/gems/**/*'
     - 'node_modules/**/*'


### PR DESCRIPTION
I'm working to set up the new rubocop to automatically correct ruby 2-7 keyword arg deprecation warnings. However this exclude is preventing the rubocop from correcting issues in config.rb.

This seems strange to exclude ruby files in the config directory from rubocop.