### PR TITLE
Use latest rubocop version and drop target ruby version

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,5 @@
 rubocop:
-  version: 0.91.0
+  version: 1.22.1
   config_file: ./ruby/.rubocop.yml
 
 jshint:

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,5 @@
 # Examples of how to specifically exclude certain things
 AllCops:
-  TargetRubyVersion: 2.7.5
   Exclude:
     - '**/*.yml'
     - '**/*.sql'


### PR DESCRIPTION
Rubocop's documentation says that it should be able to automatically select the appropriate ruby version: https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version

We can still use this setting as-needed in the repos that inherit from this style guide.