### PR TITLE
non-production updating rubocop hash and array configurations

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -13,6 +13,36 @@ AllCops:
     - !ruby/regexp /old_and_unused\.rb$/
   NewCops: enable
 
+# Configure cops for styles that we enforce and autocorrect for (where applicable)
+# Please add new configurations in alphabetical order and make sure their keys are not re-used in the section below
+
+Layout/ExtraSpacing:
+  Enabled: true
+  AllowForAlignment: true
+  AllowBeforeTrailingComments: true
+  ForceEqualSignAlignment: true
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+  EnforcedLastArgumentHashStyle: always_inspect
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
 # Configure cops for styles that we do not adhere to or are not agreed upon
 # Default settings and options can be viewed here: https://raw.githubusercontent.com/bbatsov/rubocop/master/config/default.yml
 # Please add new configurations in alphabetical order
@@ -24,12 +54,6 @@ Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
 Layout/EndOfLine:
-  Enabled: false
-
-Layout/ExtraSpacing:
-  Enabled: false
-
-Layout/HashAlignment:
   Enabled: false
 
 Layout/LineLength:


### PR DESCRIPTION
adds rubocop layout configuration to enforce and allow for auto-correction of hash and array layouts.

for example, [this diff](https://github.com/Invoca/web/pull/25512/commits/91f83c65d024adf63a2765e0b509e31acc23f630) demonstrates the auto-corrections and enforcement driven by these Cop settings when applied to `web`.