### PR TITLE
non-production/disable EnvironmentComparison and QuotedSymbols

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -161,6 +161,9 @@ Style/ParallelAssignment:
 Style/PreferredHashMethods:
   Enabled: false
 
+Style/QuotedSymbols:
+  Enabled: false
+
 Style/RegexpLiteral:
   Enabled: false
 

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -187,3 +187,6 @@ Style/TrailingUnderscoreVariable:
 
 Style/WordArray:
   EnforcedStyle: brackets
+
+Rails/EnvironmentComparison:
+  Enabled: false


### PR DESCRIPTION
I TDD'd with a file that had both of these offenses:
```ruby
if Rails.env == :'test'
  puts 'test'
end
```
and proved that they went away with these changes.