### PR TITLE
Non-production: add CountKeywordArgs: false to Metrics/ParameterLists…

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/ModuleLength:
   Max: 200
 
 Metrics/ParameterLists:
+  CountKeywordArgs: false
   Max: 10
 
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
… cop

[Per the ParameterLists documentation](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ParameterLists):

```
Keyword arguments can optionally be excluded from the total count, as they add less complexity than positional or optional parameters.
```

There are cases where it is cleaner and easier to understand several keyword arguments than to do something like pass an options hash (and you get the benefits of keyword args). I propose we exclude them from parameter count.