### PR TITLE
OMEGA-380: Add style guide rule and RuboCop config to discourage usin…

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -174,6 +174,9 @@ Style/RegexpLiteral:
 Style/RescueStandardError:
   Enabled: false
 
+Style/Send:
+  Enabled: true
+
 Style/SignalException:
   Enabled: false
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1394,49 +1394,47 @@ Private methods are private for a reason—they represent internal implementatio
 
 ```ruby
 # bad - testing private method directly
-class ShoppingCart
-  def total_with_tax
-    subtotal * (1 + tax_rate)
+class MyClass
+  def public_method
+    private_method
   end
 
   private
 
-  def tax_rate
-    # complex tax calculation logic
-    0.0825
+  def private_method
+    "does something"
   end
 end
 
 # bad test
-it "calculates correct tax rate" do
-  cart = ShoppingCart.new
-  expect(cart.send(:tax_rate)).to eq(0.0825)
+it "tests private method directly" do
+  obj = MyClass.new
+  expect(obj.send(:private_method)).to eq("does something")
 end
 
 # good - test through public interface
-it "calculates total with tax" do
-  cart = ShoppingCart.new
-  cart.add_item(item: Item.new(price: 100))
-  expect(cart.total_with_tax).to eq(108.25)
+it "tests public method behavior" do
+  obj = MyClass.new
+  expect(obj.public_method).to eq(expected_result)
 end
 
 # better - extract to testable component if complexity warrants
-class TaxCalculator
-  def self.rate_for(location:)
-    # complex tax calculation logic
-    0.0825
+class Calculator
+  def self.compute(value:)
+    # complex calculation logic
+    value * 1.5
   end
 end
 
-class ShoppingCart
-  def total_with_tax
-    subtotal * (1 + TaxCalculator.rate_for(location: location))
+class MyClass
+  def public_method
+    Calculator.compute(value: process_data)
   end
 end
 
-# now you can test TaxCalculator independently
-it "calculates correct tax rate for location" do
-  expect(TaxCalculator.rate_for(location: "CA")).to eq(0.0825)
+# now you can test Calculator independently
+it "computes value correctly" do
+  expect(Calculator.compute(value: 10)).to eq(15)
 end
 ```
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1377,7 +1377,7 @@ end
 
 ### Avoid using `send` to test private methods
 
-Private methods are private for a reason—they represent internal implementation details that should not be relied upon by external code, including tests. Testing private methods directly couples your tests to implementation rather than behavior, making refactoring difficult.
+Private methods are private for a reason — they represent internal implementation details that should not be relied upon by external code, including tests. Testing private methods directly couples your tests to implementation rather than behavior, making refactoring difficult.
 
 **Why this matters:**
 * Private methods can change or be removed without breaking the public contract

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1375,7 +1375,7 @@ end
 
 ## Testing
 
-### Avoid using `send` or `public_send` to test private methods
+### Avoid using `send` to test private methods
 
 Private methods are private for a reason—they represent internal implementation details that should not be relied upon by external code, including tests. Testing private methods directly couples your tests to implementation rather than behavior, making refactoring difficult.
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -19,6 +19,7 @@ Any adjustments to this styleguide should be captured in the [.rubocop.yml](.rub
 * [Constants](#constants)
 * [Regular Expressions](#regular-expressions)
 * [Metaprogramming](#metaprogramming)
+* [Testing](#testing)
 * [Misc](#misc)
 * [Preferred Ruby-isms](#preferred-ruby-isms)
 
@@ -1371,6 +1372,81 @@ end
 
 # best of all, though, would be to define_method as each findable attribute is declared
 ```
+
+## Testing
+
+### Avoid using `send` or `public_send` to test private methods
+
+Private methods are private for a reason—they represent internal implementation details that should not be relied upon by external code, including tests. Testing private methods directly couples your tests to implementation rather than behavior, making refactoring difficult.
+
+**Why this matters:**
+* Private methods can change or be removed without breaking the public contract
+* Tests that use `send` to access private methods become brittle and harder to maintain
+* It violates encapsulation and can lead to over-specified tests
+* It makes it unclear what the actual public API of your class is
+
+**What to do instead:**
+* Test the public interface of your class—private methods should be tested indirectly through the public methods that use them
+* If a private method is complex enough that you feel it needs direct testing, it's probably a sign that it should be:
+  - Extracted into its own class with a public interface
+  - Moved to a module or helper that can be tested independently
+  - Reconsidered as a protected or public method if other objects legitimately need it
+
+```ruby
+# bad - testing private method directly
+class ShoppingCart
+  def total_with_tax
+    subtotal * (1 + tax_rate)
+  end
+
+  private
+
+  def tax_rate
+    # complex tax calculation logic
+    0.0825
+  end
+end
+
+# bad test
+it "calculates correct tax rate" do
+  cart = ShoppingCart.new
+  expect(cart.send(:tax_rate)).to eq(0.0825)
+end
+
+# good - test through public interface
+it "calculates total with tax" do
+  cart = ShoppingCart.new
+  cart.add_item(item: Item.new(price: 100))
+  expect(cart.total_with_tax).to eq(108.25)
+end
+
+# better - extract to testable component if complexity warrants
+class TaxCalculator
+  def self.rate_for(location:)
+    # complex tax calculation logic
+    0.0825
+  end
+end
+
+class ShoppingCart
+  def total_with_tax
+    subtotal * (1 + TaxCalculator.rate_for(location: location))
+  end
+end
+
+# now you can test TaxCalculator independently
+it "calculates correct tax rate for location" do
+  expect(TaxCalculator.rate_for(location: "CA")).to eq(0.0825)
+end
+```
+
+**When it might be acceptable:**
+In rare cases, you might have a legitimate reason to use `send` in tests:
+* Testing legacy code that cannot be refactored safely
+* Verifying specific edge cases in private methods during a major refactoring (with the intent to remove after refactoring is complete)
+* Testing framework internals where you're explicitly testing private implementation
+
+If you find yourself in one of these situations, document why with a clear comment and consider whether there's a better approach.
 
 ## Misc
 


### PR DESCRIPTION
…g send in tests

This commit adds a new Testing section to the Ruby style guide that explains why developers should avoid using send/public_send to test private methods. The guide includes clear examples of anti-patterns and better alternatives, such as testing through public interfaces or extracting complex logic into separate testable classes.

Also enables the Style/Send RuboCop cop to help enforce this guideline.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Send