### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Code ownership for this repository
-* @Invoca/front-end-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code ownership for this repository
+* @Invoca/front-end-platform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,5 +11,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: front-end-platform
-  # system: TODO — see https://github.com/Invoca/backstage-catalog
+  owner: dev-managers
+  system: developer-tooling

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: style-guide
+  title: style-guide
+  description: "Centralized repository for all of Invoca's language style guides and HoundCI config"
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/style-guide/
+    github.com/project-slug: Invoca/style-guide
+    buildkite.com/project-slug: invoca/style-guide
+spec:
+  type: service
+  lifecycle: production
+  owner: front-end-platform
+  # system: TODO — see https://github.com/Invoca/backstage-catalog


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `service` (inferred from repo name/language)
- **owner**: `front-end-platform`
- **system**: **⚠ not set — please add before merging**

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://github.com/Invoca/backstage-catalog))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
