### PR TITLE
non-production: disable Style/Send cop; custom cop coming instead

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -174,9 +174,6 @@ Style/RegexpLiteral:
 Style/RescueStandardError:
   Enabled: false
 
-Style/Send:
-  Enabled: true
-
 Style/SignalException:
   Enabled: false
 


### PR DESCRIPTION
## Summary
- Reverts the `Style/Send` RuboCop cop that was enabled in #OMEGA-380
- The built-in cop is too broad; a more fine-tuned custom cop will replace it
- Style guide documentation (README) remains in place

## Test plan
- [ ] Verify `Style/Send` is no longer enforced in consuming repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)